### PR TITLE
feat: Añadir formularios de registro de libros en HTML y PHP

### DIFF
--- a/registro_libros.html
+++ b/registro_libros.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Registro de Libros - Librería en Línea</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="bg-primary text-white text-center py-3">
+    <h1>Registro de Libros</h1>
+  </header>
+  <main class="container mt-4">
+    <div class="row justify-content-center">
+      <div class="col-md-6">
+        <div class="card">
+          <div class="card-header">Registro de Libros</div>
+          <div class="card-body">
+            <form action="registro_libros.php" method="POST">
+              <div class="form-group">
+                <label for="titulo">Título</label>
+                <input type="text" class="form-control" id="titulo" name="titulo" required>
+              </div>
+              <div class="form-group">
+                <label for="autor">Autor</label>
+                <input type="text" class="form-control" id="autor" name="autor" required>
+              </div>
+              <div class="form-group">
+                <label for="precio">Precio</label>
+                <input type="number" class="form-control" id="precio" name="precio" required>
+              </div>
+              <button type="submit" class="btn btn-primary btn-block">Registrar Libro</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-dark text-white text-center py-3">
+    <p>&copy; 2023 Librería en Línea. Todos los derechos reservados.</p>
+  </footer>
+</body>
+</html>

--- a/registro_libros.php
+++ b/registro_libros.php
@@ -1,0 +1,23 @@
+<?php
+include 'config.php'; // Archivo con la configuración de la base de datos
+
+if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    $titulo = filter_var($_POST['titulo'], FILTER_SANITIZE_STRING);
+    $autor = filter_var($_POST['autor'], FILTER_SANITIZE_STRING);
+    $precio = filter_var($_POST['precio'], FILTER_VALIDATE_FLOAT);
+
+    // Insertar datos en la base de datos
+    $stmt = $conn->prepare("INSERT INTO libros (titulo, autor, precio) VALUES (?, ?, ?)");
+    $stmt->bind_param("ssd", $titulo, $autor, $precio);
+    $stmt->execute();
+
+    if ($stmt->affected_rows > 0) {
+        echo "Libro registrado exitosamente.";
+    } else {
+        echo "Error al registrar el libro.";
+    }
+
+    $stmt->close();
+    $conn->close();
+}
+?>


### PR DESCRIPTION
Se añaden dos nuevos formularios para el registro de libros. Uno en HTML (registro_libros.html) para la interfaz del usuario y otro en PHP (registro_libros.php) para manejar la lógica de backend. Estos formularios permiten a los usuarios ingresar detalles de nuevos libros y registrar la información en la base de datos.